### PR TITLE
Direct to all engineering roles

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,17 +4,5 @@
     {% assign default_paths = site.pages | map: "path" %}
     {% assign page_paths = site.header_pages | default: default_paths %}
     {% include headersvg.html %}
-    <div class="news-brand">
-      <div class="news-red">
-          <span>
-            <svg xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true" viewBox="3367.9 3.96 61 15.33" width="120px" enable-background="new 3367.9 3.96 61 15.33" preserveAspectRatio="xMinYMin meet">
-              <g fill="#fff">
-                <path d="M3379.73 4.15h2.03v14.97h-1.84l-10.01-11.53v11.53h-2.01V4.15h1.74l10.09 11.62V4.15M3385.62 4.15h8.49v1.91h-6.34v4.56h6.13v1.92h-6.13v4.65h6.54v1.9h-8.69V4.15M3416.97 4.15h2.14l-6.05 15.03h-.47l-4.89-12.17-4.95 12.17h-.46l-6.03-15.03h2.16l4.12 10.32 4.16-10.32h2.02l4.17 10.32 4.08-10.32M3424.92 12.85l-1.63-.99c-1.02-.62-1.75-1.24-2.18-1.84-.43-.6-.65-1.3-.65-2.08 0-1.18.41-2.14 1.23-2.87.82-.74 1.88-1.1 3.19-1.1 1.25 0 2.4.35 3.44 1.05v2.43c-1.08-1.04-2.24-1.56-3.48-1.56-.7 0-1.27.16-1.73.49-.45.32-.67.74-.67 1.24 0 .45.17.87.5 1.26.33.39.86.8 1.6 1.23l1.64.97c1.82 1.09 2.74 2.48 2.74 4.16 0 1.2-.4 2.17-1.21 2.92-.8.75-1.85 1.12-3.13 1.12-1.48 0-2.82-.45-4.04-1.36V15.2c1.16 1.47 2.5 2.2 4.02 2.2.67 0 1.23-.19 1.68-.56.45-.37.67-.84.67-1.4-.02-.91-.68-1.78-1.99-2.59"></path>
-                <image src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHoAAAAgCAMAAADqkpxHAAAAG1BMVEX////35+fvxsbnra3ejIzWa2vOUlLGMTG9GBibW0q6AAAACXRSTlP//////////wBTT3gSAAACWUlEQVR4nLyX65aFIAiFE/Hy/k88pagbpDOetWaNv6yQD2FLddV/HiVnmV33CI4F3/dJ5vEygx8XzySbVdHzBoaF2vpALPcn4xt0fbxEh2LjWZ4E3JHcjTcXJ+i875A9Zzcv8JitESo6+4gOMHjuQa+TdKp7T4TXekrEkRR6Y1v0LzVZFOsrjjzk9aikAOjwWqFX9Ca0URhlO40YgypME32RZh+gN6E9bpKJZ/l5ZgUedDTv7BO0EVrz0uIB4+cytVmw4m/ovkrJ4wRthNavdDxLZHVTZUf3E4fJO0FroTVKMfHE5ba1G8i4oIUNQR2hm9CSoTBuGyrfQguAEHQtQbOP0Epog4LCV2khc/IGuq9YQZ2hobBrAQhtiWzubjEmukuNhuHHRqq3zWaWZ1GzNhb2OEvgKuERO0SnYQaUJTQQWX/CwmaDln1/hZ6FRcoUGlRdRpaNR4OWN4+PxtcH+CLwMygjnq3Jw8ajQfcjRh7al9kUmqaI0JTIFrxvnDUajtgpWuSlW1WLJxddG7PxUGztBvsY3QzZUFokVmSGHQ1ajnc+R7e82f6cmjgu9arCQbJGZyX1bJyjx2cPSrnIvY8K2dDyFjtHZ48i8WAmcD5Cs1rgy8T8Gb31ZohHmYFFcRMO36yH6OSg6/YWvu+sy+jJDNmH6LJR6vhkMcGMN0d7mDz0OPWIxmYWzALypOyXnygyiXMXLTJ47eEmBdlLCtlOxtpHfUF3mZyib8z2C/F4sPvB/57yilYthYMZFp08D+T8TfVkU6+5t+hvht/ISpmt5wcAAP//AwCBpFE5ZTGfKQAAAABJRU5ErkJggg=="></image>
-              </g>
-            </svg>
-          </span>
-      </div>
-    </div>
   </div>
 </header>

--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-title: BBC Digital and Engineering (D+E)
+title: BBC Design and Engineering (D+E)
 ---
 
 # Join Us

--- a/index.md
+++ b/index.md
@@ -1,19 +1,15 @@
 ---
-title: BBC Digital Products
+title: BBC Digital and Engineering (D+E)
 ---
 
 # Join Us
 
-We're looking for app and web software engineers.
+We're looking for Software Engineers, Technologists, and lots of other disciplines.
 
-Come and join us in delivering the BBC's news services across the globe to **hundreds of millions of readers in over 40 languages.**
+Come and join us in delivering the BBC's services across the globe to **half a billion listeners, readers and viewers in over 40 languages.**
 
-We work in agile, lean, and flexible teams, with an innovating roadmap for News on a wide variety of platforms. As you might imagine, massive scale, performance, and accessibility are all important in our line of work as well as support for a wide range of devices. Given the trusted place of BBC News we work carefully and responsibly to deliver the best possible online news service.
+We work in agile, lean, and flexible teams, with an innovating roadmap on a wide variety of platforms. As you might imagine, massive scale, performance, and accessibility are all important in our line of work as well as support for a wide range of devices. Given the trusted place of the BBC brand we work carefully and responsibly to deliver the best possible online services.
 
-## Currently Open...
+## You can find all our open roles...
 
-**No vacancies currently open**
-
-## Even more vacancies...
-
-You can find available open vacancies across BBC News on the [BBC Career portal](https://careerssearch.bbc.co.uk/jobs/search) by searching for 'News'.
+You can also search more widely by changing the filter criteria on this link [BBC Career Hub: Engineering, Technology, Systems & Delivery roles](https://careerssearch.bbc.co.uk/jobs/category/57).

--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ title: BBC Design and Engineering (D+E)
 
 # Join Us
 
-We're looking for Software Engineers, Technologists, and lots of other disciplines.
+We're looking for Software Engineers, Test Engineers, User Experience Designers and lots of other disciplines.
 
 Come and join us in delivering the BBC's services across the globe to **half a billion listeners, readers and viewers in over 40 languages.**
 


### PR DESCRIPTION
- Removes News specific words and branding
- Directs viewers to filtered view of careershub so we don't need to manually update this page.