### PR TITLE
Add alt attribute

### DIFF
--- a/_includes/headersvg.html
+++ b/_includes/headersvg.html
@@ -1,1 +1,1 @@
-<img src="assets/svg/blq-orbit-blocks_grey.svg"></img>
+<img src="assets/svg/blq-orbit-blocks_grey.svg" alt="BBC"></img>


### PR DESCRIPTION
Running lighthouse on this page, we see that we do not have an alt attribute on an image. This PR adds an alt attribute.

<img width="877" alt="Screenshot of lighthouse errors" src="https://user-images.githubusercontent.com/3028997/82880627-9b40ff80-9f36-11ea-90da-67fa97862f9a.png">
