### PR TITLE
Accessibility - Fix colour contrast

### DIFF
--- a/_sass/minima.scss
+++ b/_sass/minima.scss
@@ -11,8 +11,8 @@ $base-line-height: 1.5 !default;
 $spacing-unit:     30px !default;
 
 $text-color:       #111 !default;
+$link-color:       #0F556C !default;
 $background-color: #fdfdfd !default;
-$brand-color:      #2a7ae2 !default;
 
 $grey-color:       #828282 !default;
 $grey-color-light: lighten($grey-color, 40%) !default;

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -91,19 +91,21 @@ h1, h2, h3, h4, h5, h6 {
  * Links
  */
 a {
-  color: $brand-color;
+  color: $link-color;
   text-decoration: none;
 
   &:visited {
-    color: darken($brand-color, 15%);
+    color: darken($link-color, 15%);
   }
 
-  &:hover {
-    color: $text-color;
+  &:hover,
+  &:focus {
+    color: $link-color;
     text-decoration: underline;
   }
 
-  .social-media-list &:hover {
+  .social-media-list &:hover,
+  .social-media-list &:focus {
     text-decoration: none;
 
     .username {


### PR DESCRIPTION
Using the Axe tool I can see there is a colour contrast issue with the current link styles. This PR fixes that, plus ensures the link hover styles apply when focusing too. 

<img width="1440" alt="Screenshot lighthouse bbc join us colour contrast" src="https://user-images.githubusercontent.com/3028997/82895433-2082df00-9f4c-11ea-83c3-e5a7662a5de7.png">
